### PR TITLE
Add Contao to the project list

### DIFF
--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -1,5 +1,9 @@
 # put the newest to the top
 
+- name: Contao
+  url: https://github.com/contao/contao
+  since: 2018
+
 - name: Shopsys
   url: https://github.com/shopsys/shopsys
   since: 2018


### PR DESCRIPTION
This adds Contao to the list of monorepo projects. Our brand new monorepo is here: https://github.com/contao/contao