### PR TITLE
include composer-monorepo-plugin in tools list

### DIFF
--- a/source/_data/tools.yaml
+++ b/source/_data/tools.yaml
@@ -8,3 +8,7 @@ parameters:
             name: "shopsys/monorepo-tools"
             url: "https://github.com/shopsys/monorepo-tools"
             description: "merges history of multiple repos to one and more - great for start for code with many repositories with long history"
+        -
+            name: "beberlei/composer-monorepo-plugin"
+            url: "https://github.com/beberlei/composer-monorepo-plugin"
+            description: "manage composer autoloading with external and internal dependencies when using a monorepo"


### PR DESCRIPTION
composer-monorepo-plugin prevents dependency conflict of external libraries and automatically configures tailored autoloading to each component in you monorepo